### PR TITLE
Small improvements to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Permettre aux gens de trouver des produits sans emballage
 
-Récolter des données sur les utilisateurs
+RÃ©colter des donnÃ©es sur les utilisateurs
 
-Conquérir le monde
+ConquÃ©rir le monde
 
 ## Install
 
@@ -17,7 +17,7 @@ Install dependencies:
 Initialize database tables:
 
 ```bash
-$ python python manage.py migrate
+$ python manage.py migrate
 ```
 
 Create a super-user for the admin:
@@ -26,8 +26,18 @@ Create a super-user for the admin:
 $ python manage.py createsuperuser
 ```
 
-## Run
+## Run the development server
 
 ```bash
 $ python manage.py runserver
 ```
+
+> Default port is 8000, if it is already taken, you can start the development server on another port by appending the port number to above command.  For example, to run on port 9000 : `python manage.py runserver 9000`
+
+## Use
+
+Use the webapp by visiting the site at the URL printed by `runserver` (defaults to `http://localhost:8000`).
+
+## Administer the site
+
+Visit `/admin`, using the user credentials you've created for the _super-user_ above, in order to adminster the site : add species, products and sellers.


### PR DESCRIPTION
Use UTF8 encoding; remove word duplication in database initialization command; add instructions on how to start on another port and point to /admin URI.